### PR TITLE
feat: add option to hydrate when entering the viewport

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -1,0 +1,6 @@
+export * from './use-viewport-listener'
+export * from './use-window-listeners'
+
+export function isIntersectionObserverSupported() {
+  return window && 'IntersectionObserver' in window
+}

--- a/src/runtime/composables/use-viewport-listener.ts
+++ b/src/runtime/composables/use-viewport-listener.ts
@@ -1,0 +1,25 @@
+import type { Ref, RendererNode } from 'vue'
+import { nextTick, onMounted, onBeforeUnmount } from 'vue'
+
+export function useViewportListener(node: RendererNode, shouldRender: Ref<boolean>) {
+  const observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) {
+      shouldRender.value = true
+      observer.disconnect()
+    }
+  }, {
+    root: null,
+    rootMargin: '0px',
+    threshold: 0.5,
+  })
+
+  onBeforeUnmount(() => {
+    observer.disconnect()
+  })
+
+  onMounted(() => {
+    nextTick(() =>
+      observer.observe(node.previousElementSibling),
+    )
+  })
+}

--- a/src/runtime/composables/use-window-listeners.ts
+++ b/src/runtime/composables/use-window-listeners.ts
@@ -1,0 +1,69 @@
+import type { Ref } from 'vue'
+import { delayHydrationOptions } from '#build/module/nuxt-vitalizer'
+import { onMounted, useNuxtApp } from '#imports'
+
+interface Handler {
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  promise: Promise<void | Event>
+  cleanup: () => void
+}
+
+export function useWindowListeners(shouldRender: Ref<boolean>) {
+  const nuxtApp = useNuxtApp()
+
+  onMounted(async () => {
+    const triggers = [idleListener(), eventListeners()]
+    nuxtApp._delayHydrationPromise ??= Promise.race(
+      triggers.map(t => t.promise),
+    ).finally(() => {
+      for (const t of triggers) t.cleanup()
+    })
+
+    await nuxtApp._delayHydrationPromise
+    shouldRender.value = true
+  })
+}
+
+function eventListeners(): Handler {
+  const abortController = new AbortController()
+  const promise = new Promise<Event>((resolve) => {
+    const listener = (e: Event) => {
+      for (const e of delayHydrationOptions.hydrateOnEvents) window.removeEventListener(e, listener)
+      requestAnimationFrame(() => resolve(e))
+    }
+
+    for (const e of delayHydrationOptions.hydrateOnEvents) {
+      window.addEventListener(e, listener, {
+        capture: true,
+        once: true,
+        passive: true,
+        signal: abortController.signal,
+      })
+    }
+  })
+
+  return {
+    promise,
+    cleanup: () => abortController.abort(),
+  }
+}
+
+function idleListener(): Handler {
+  let idleId: number
+
+  const promise = new Promise<void>((resolve) => {
+    const timeoutDelay = () => {
+      setTimeout(() => {
+        requestAnimationFrame(() => resolve())
+      }, delayHydrationOptions.postIdleTimeout)
+    }
+    idleId = requestIdleCallback(timeoutDelay, {
+      timeout: delayHydrationOptions.idleCallbackTimeout,
+    })
+  })
+
+  return {
+    promise,
+    cleanup: () => cancelIdleCallback(idleId),
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/johannschopplich/nuxt-vitalizer/issues/5

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Adds the option `hydreate-when-visible` for `DelayHydration` which prevents running the default listeners and instead rely on `IntersectionObserver` to verify if the previous sibling is entering the viewport thus hydrating the slot.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
